### PR TITLE
Disable SearchInput autocomplete and add config option for source code URL

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,7 +1,9 @@
+import CONFIG from "../config";
+
 const Footer = () => (
   <footer>
     <p>
-      <a href="https://github.com/katmh/mitier">source code</a>
+      <a href={CONFIG.SOURCE_CODE_URL}>source code</a>
     </p>
     <style jsx>{`
       footer {

--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -9,6 +9,7 @@ export default class SearchInput extends React.Component {
           id="search"
           name="search"
           type="text"
+          autocomplete="off"
           placeholder={CONFIG.SEARCH.INPUT_PLACEHOLDER}
           onChange={this.props.onChange}
         />

--- a/config.js
+++ b/config.js
@@ -30,6 +30,7 @@ const CONFIG = {
     NO_RESULTS_MESSAGE: "No results :(",
     LOADING_MESSAGE: "Loading...",
   },
+  SOURCE_CODE_URL: "https://github.com/katmh/mitier",
 };
 
 export default CONFIG;


### PR DESCRIPTION
Hi! Thank you so much for making this! Setting it up for my school was super straightforward with your documentation, and my friends and I are really enjoying making tier lists with it now :) 

I noticed that an autocomplete dropdown was blocking the search dropdown in my browser:
<img width="597" alt="Screen Shot 2021-02-13 at 7 47 05 PM" src="https://user-images.githubusercontent.com/7040416/107866374-d58c5d00-6e35-11eb-9d79-2d4a06e1eb2d.png">

I added the `autocomplete="off"` attribute in SearchInput.js to prevent this.

I also added an option for the source code URL in config.js, so it's easier for people who want to point the link towards their own fork to do so. 

Let me know if there's anything I should change or add. Thanks again!